### PR TITLE
Add selectable play modes and scenario support

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,35 @@
         <section id="tab-overview" class="tab-panel active" role="tabpanel">
           <h2>Hospital Overview</h2>
           <p>Balance your hospital's prestige, finance, and patient care. Keep staff happy and the wards running smoothly.</p>
+          <section class="mode-selector" aria-label="Play modes">
+            <h3>Choose Play Mode</h3>
+            <div class="mode-buttons" role="group" aria-label="Play mode selection">
+              <button type="button" class="play-mode-button active" data-play-mode="career">Career</button>
+              <button type="button" class="play-mode-button" data-play-mode="free">Free Play</button>
+              <button type="button" class="play-mode-button" data-play-mode="scenario">Scenarios</button>
+            </div>
+            <p id="play-mode-description" class="mode-description">
+              Grow your hospital over time, complete objectives, and expand your campus.
+            </p>
+            <div id="scenario-options" class="scenario-options" hidden>
+              <h4>Scenario Select</h4>
+              <div class="scenario-list">
+                <button type="button" class="scenario-button" data-scenario="stormwatch">
+                  <strong>Stormwatch Surge</strong>
+                  <span>Stabilize emergencies with limited funds.</span>
+                </button>
+                <button type="button" class="scenario-button" data-scenario="wellness">
+                  <strong>Wellness Retreat</strong>
+                  <span>Transform the campus into a calming sanctuary.</span>
+                </button>
+                <button type="button" class="scenario-button" data-scenario="investor">
+                  <strong>Investor Showcase</strong>
+                  <span>Impress investors with bold expansion.</span>
+                </button>
+              </div>
+            </div>
+            <p id="play-mode-summary" class="mode-summary">Build up prestige, unlock parcels, and complete objectives to progress your career.</p>
+          </section>
           <div class="meter">
             <label for="meter-cleanliness">Cleanliness</label>
             <progress id="meter-cleanliness" value="80" max="100"></progress>

--- a/styles.css
+++ b/styles.css
@@ -191,6 +191,135 @@ main {
   margin-top: 0;
 }
 
+.mode-selector {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+}
+
+.mode-selector h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.mode-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.play-mode-button {
+  border: none;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  color: var(--text);
+  padding: 0.45rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.play-mode-button:hover,
+.play-mode-button:focus {
+  background: rgba(59, 130, 246, 0.35);
+  transform: translateY(-1px);
+}
+
+.play-mode-button.active {
+  background: var(--accent);
+  color: #111827;
+  box-shadow: 0 4px 12px rgba(249, 115, 22, 0.35);
+}
+
+.mode-description {
+  margin: 0;
+  font-size: 0.88rem;
+  color: rgba(203, 213, 225, 0.9);
+  line-height: 1.5;
+}
+
+.mode-summary {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 197, 255, 0.85);
+}
+
+.scenario-options {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+}
+
+.scenario-options h4 {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.scenario-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.scenario-button {
+  border: none;
+  background: rgba(30, 41, 59, 0.75);
+  border-radius: 0.75rem;
+  padding: 0.75rem 0.85rem;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.scenario-button strong {
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.scenario-button span {
+  font-size: 0.8rem;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.scenario-button:hover,
+.scenario-button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.4);
+  background: rgba(59, 130, 246, 0.25);
+}
+
+.scenario-button.active {
+  background: rgba(249, 115, 22, 0.8);
+  color: #111827;
+  box-shadow: 0 8px 18px rgba(249, 115, 22, 0.4);
+}
+
+.objectives li.objective-empty {
+  color: rgba(203, 213, 225, 0.7);
+  font-style: italic;
+}
+
 .tabs {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add an overview play mode selector for career, free play, and curated scenarios
- define play mode/scenario data with state reset logic so each mode reinitializes resources and goals appropriately
- style the new selector and update objective messaging for modes without active goals

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc3fb2abd48331866c13399754acf4